### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/page.yml
+++ b/.github/workflows/page.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - setup.py
 
+permissions:
+  contents: write
+
 jobs:
   update-download-links:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/nayandas69/Social-Media-Downloader/security/code-scanning/5](https://github.com/nayandas69/Social-Media-Downloader/security/code-scanning/5)

To fix the issue, we need to explicitly define a `permissions` block at the workflow level or for the specific job. Since this workflow performs actions such as checking out the repository, reading files, and pushing changes, the following permissions are required:
- `contents: write` to allow the workflow to commit and push changes to the repository.

Adding the `permissions` block at the workflow level ensures that all jobs in the workflow inherit these permissions unless overridden. This approach is sufficient for the current workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
