### PR TITLE
Add Support for SnackVideo and Kwai Platforms

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -6,8 +6,8 @@ We only provide security updates and support for the **latest released version**
 
 | Version | Supported |
 |---------|-----------|
-| 1.1.4   | ✅         |
-| < 1.1.2 | ❌         |
+| 1.1.6   | ✅         |
+| < 1.1.4 | ❌         |
 
 > [!NOTE]
 > To stay safe and secure, **always update to the latest version**. We do not support or patch older versions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All the spicy updates, tweaks, and new vibes are logged here. 🌟
 
 ---
 
+## [1.1.6] - 2025-05-11
+### Added
+- Support for two new video platforms:
+  - SnackVideo (`snackvideo.com`)
+  - Kwai (`kwai.com`)
+
+
+---
+
 ## [1.1.5] - 2025-05-10
 
 ### Fixes & Improvements

--- a/downloader.py
+++ b/downloader.py
@@ -578,7 +578,7 @@ def show_help():
     )
     print("\033[1;32mSupported Platforms:\033[0m")
     print(
-        "• YouTube, Instagram, Facebook, TikTok, X, Twitch, Snapchat, Reddit, Vimeo, Streamable, Pinterest, LinkedIn, Bilibili, Odysee, Rumble, GameClips & Triller.\n"
+        "• YouTube, Instagram, Facebook, TikTok, X, Twitch, Snapchat, Reddit, Vimeo, Streamable, Pinterest, LinkedIn, Bilibili, Odysee, Rumble, GameClips, Triller, SnackVideo & Kwai.\n"
     )
 
     print("\033[1;32mAdditional Information:\033[0m")

--- a/downloader.py
+++ b/downloader.py
@@ -3,7 +3,7 @@
 
 # -----------------------------------------
 # Social Media Downloader
-# Version: 1.1.5
+# Version: 1.1.6
 # Author: Nayan Das
 # License: MIT
 # Description: A command-line tool to download videos from various social media platforms like YouTube, TikTok, Facebook, Instagram, X & more.
@@ -12,7 +12,7 @@
 # Usage: pip install social-media-downloader
 # Requirements: Python 3.6+
 # Note: Ensure FFmpeg is installed and added to your PATH for audio extraction.
-# Last Updated: 10th May 2025
+# Last Updated: 11th May 2025
 # -----------------------------------------
 
 import os
@@ -38,7 +38,7 @@ from concurrent.futures import ThreadPoolExecutor
 # Version and Update Variables
 # ---------------------------------
 AUTHOR = "Nayan Das"
-CURRENT_VERSION = "1.1.5"
+CURRENT_VERSION = "1.1.6"
 EMAIL = "nayanchandradas@hotmail.com"
 DISCORD_INVITE = "https://discord.gg/skHyssu"
 WEBSITE = "https://nayandas69.github.io/link-in-bio"
@@ -332,6 +332,8 @@ def download_youtube_or_tiktok_video(url):
         "rumble.com",
         "gameclips.io",
         "triller.co",
+        "snackvideo.com",
+        "kwai.com",
     ]
     if not is_valid_platform_url(url, allowed_domains):
         print("\n\033[1;31mInvalid URL. Please enter a valid URL.\033[0m")
@@ -558,7 +560,7 @@ def show_help():
     """Display the help menu with usage instructions."""
     print("\n\033[1;36mHow to Use Social Media Downloader:\033[0m")
     print(
-        "1. \033[1;33mDownload Videos:\033[0m Enter '1' to download a public YouTube, Facebook, TikTok, X, Twitch, Snapchat, Reddit, Vimeo, Streamable, Pinterest, LinkedIn, Bilibili, Odysee, Rumble, GameClips & Triller videos."
+        "1. \033[1;33mDownload Videos:\033[0m Enter '1' to download a public YouTube, Facebook, TikTok, X, Twitch, Snapchat, Reddit, Vimeo, Streamable, Pinterest, LinkedIn, Bilibili, Odysee, Rumble, GameClips, Triller, Snackvideo & kwai videos."
     )
     print(
         "2. \033[1;33mDownload Instagram Content:\033[0m Enter '2' to download a public Instagram post, video, reel, picture. And for Batch download provide a text file containing public Instagram post URLs."

--- a/downloader.py
+++ b/downloader.py
@@ -338,7 +338,7 @@ def download_youtube_or_tiktok_video(url):
     if not is_valid_platform_url(url, allowed_domains):
         print("\n\033[1;31mInvalid URL. Please enter a valid URL.\033[0m")
         print(
-            "\033[1;31mSupported platforms: YouTube, Facebook, TikTok, X, Twitch, Snapchat, Reddit, Vimeo, Streamable, Pinterest, LinkedIn, Bilibili, Odysee, Rumble, GameClips & Triller.\033[0m"
+            "\033[1;31mSupported platforms: YouTube, Facebook, TikTok, X, Twitch, Snapchat, Reddit, Vimeo, Streamable, Pinterest, LinkedIn, Bilibili, Odysee, Rumble, GameClips Triller, SnackVideo & Kwai.\033[0m"
         )
         return
 

--- a/downloader.py
+++ b/downloader.py
@@ -338,7 +338,7 @@ def download_youtube_or_tiktok_video(url):
     if not is_valid_platform_url(url, allowed_domains):
         print("\n\033[1;31mInvalid URL. Please enter a valid URL.\033[0m")
         print(
-            "\033[1;31mSupported platforms: YouTube, Facebook, TikTok, X, Twitch, Snapchat, Reddit, Vimeo, Streamable, Pinterest, LinkedIn, Bilibili, Odysee, Rumble, GameClips Triller, SnackVideo & Kwai.\033[0m"
+            "\033[1;31mSupported platforms: YouTube, Facebook, TikTok, X, Twitch, Snapchat, Reddit, Vimeo, Streamable, Pinterest, LinkedIn, Bilibili, Odysee, Rumble, GameClips, Triller, SnackVideo & Kwai.\033[0m"
         )
         return
 

--- a/whats_new.md
+++ b/whats_new.md
@@ -1,16 +1,10 @@
-# What's New in Social Media Downloader v1.1.5
+# What's New in Social Media Downloader v1.1.6
 
-### MP3 Quality Fix
-- Fixed a bug where custom `mp3_quality` values (e.g., 256, 320) were ignored.
-- Now respects and validates values from `config.json`.
+We’ve expanded platform support in this update! You can now download videos from two additional platforms:
 
-### Improved Validation
-- Falls back to default `192` if invalid quality is set.
-- Logs a warning for incorrect config values.
+- **SnackVideo** (`snackvideo.com`)
+- **Kwai** (`kwai.com`)
 
-### Docs Moved!
-All documentation is now hosted separately:  
-[https://nayandas69.github.io/smd-docsite/](https://nayandas69.github.io/smd-docsite/)
+This brings even more flexibility to your content downloading experience across short-video platforms.
 
-New docs repo:  
-[https://github.com/nayandas69/smd-docsite](https://github.com/nayandas69/smd-docsite)
+As always, thanks for using the tool!


### PR DESCRIPTION
Adds support for downloading videos from two new short-form video platforms:

- `snackvideo.com` (SnackVideo)  
- `kwai.com` (Kwai)

These additions enhance the downloader's compatibility with popular social media content.

## Changes Made
- Updated the `allowed_domains` list in the `download_youtube_or_tiktok_video()` function to include:
  - `snackvideo.com`
  - `kwai.com`

## Related Updates
- Changelog updated for version **1.1.6** (`2025-05-11`)
- New entry added to `whats_new.md` outlining the changes

## Notes
No other functionality was modified. This is a safe, additive change with no breaking impact.