### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-archive.yml
+++ b/.github/workflows/update-archive.yml
@@ -1,5 +1,8 @@
 name: Update Archive
 
+permissions:
+  contents: write
+
 on:
   schedule:
     - cron: '0 0 * * 0'   # Every Sunday at midnight UTC


### PR DESCRIPTION
Potential fix for [https://github.com/nayandas69/Social-Media-Downloader/security/code-scanning/6](https://github.com/nayandas69/Social-Media-Downloader/security/code-scanning/6)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow involves checking out the repository, installing dependencies, running a Python script, and committing and pushing changes, the minimal required permissions are `contents: write`. This ensures that the workflow has the necessary access to modify the repository contents while adhering to the principle of least privilege.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs. This is the most straightforward approach since there is only one job in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
