### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Run Python Tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ dev ]


### PR DESCRIPTION
Potential fix for [https://github.com/nayandas69/Social-Media-Downloader/security/code-scanning/7](https://github.com/nayandas69/Social-Media-Downloader/security/code-scanning/7)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow only checks out code, sets up Python, installs dependencies, and runs tests, it only requires read access to the repository contents. The `permissions` block should be added at the root level of the workflow to apply to all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
